### PR TITLE
feat: add query param to cache bust image urls

### DIFF
--- a/src/s3bucket.rs
+++ b/src/s3bucket.rs
@@ -1,4 +1,5 @@
 use std::str::FromStr;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::{bail, Context as AnyhowContext};
 use mime::Mime;
@@ -75,8 +76,12 @@ pub async fn upload_image_to_s3bucket(
     }
 
     Ok(format!(
-        "{}/{}{}{}",
-        config.storage.url, config.storage.bucket_name, config.storage.storage_path, uid
+        "{}/{}{}{}?{}.gif",
+        config.storage.url,
+        config.storage.bucket_name,
+        config.storage.storage_path,
+        uid,
+        SystemTime::now().duration_since(UNIX_EPOCH).expect("Could not get unix timestamp").as_millis()
     ))
 }
 
@@ -91,9 +96,7 @@ pub async fn delete_image_from_s3_bucket(ctx: &Context, uid: String) -> Result<(
 
     let path = format!("{}{}", config.storage.storage_path, uid);
 
-    let response = bucket
-        .delete_object(path.clone())
-        .await?;
+    let response = bucket.delete_object(path.clone()).await?;
 
     if response.status_code() != 204 {
         bail!("Error deleting image from minio")


### PR DESCRIPTION
Currently, when a background is approved, if a user has recently had another image approved Discord will show the old background in the "Approved" embeded due to its media cache. Additionally, `.gif` is added to the end of the URL so Discord will treat the image as a gif when displaying in an embed (because Discord is incredibly big brain and ignores mime types and uses file extensions instead for gif detection).

(Side note that this builds but I haven't actually run and tested it because I do not have the environment set up to do that.)